### PR TITLE
FIXIN unbind 'client.del' function

### DIFF
--- a/lib/redis-cookie-store.js
+++ b/lib/redis-cookie-store.js
@@ -157,7 +157,7 @@ RedisCookieStore.prototype.removeCookies = function removeCookies(domain, path, 
       return;
     }
 
-    async.each(keys, client.del, cb);
+    async.each(keys, client.del.bind(client), cb);
   });
 };
 


### PR DESCRIPTION
It resolves the "Cannot read property 'internal_send_command' of undefined" problem when you try something like:
> cookiesJar.store.removeCookies('domain.com', null, function (err) { ... })
...or:
> cookiesJar.store.removeCookies('*', null, function (err) { ... })

I'm using node v10.14.0